### PR TITLE
feat: Rework visual hierarchy with new base layer.

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -32,6 +32,10 @@
 		backdrop-filter: blur(4px);
 	}
 
+	.maplibregl-ctrl-attrib.maplibregl-compact-show {
+		@apply my-0!;
+	}
+
 	.floating-panel {
 		@apply border-earth bg-smog rounded-sm border border-solid shadow-md;
 	}
@@ -49,12 +53,12 @@
 	}
 
 	.logo-container {
-		@apply fixed right-[3%] bottom-[55px] z-10 flex h-[20px] w-[20px] items-center justify-center opacity-80 transition-opacity duration-200;
+		@apply fixed right-[calc(3%+2rem)] bottom-6 z-10 flex h-[20px] w-[20px] items-center justify-center opacity-80 transition-opacity duration-200;
 	}
 
 	@media (min-width: 768px) {
 		.logo-container {
-			@apply right-4 bottom-4;
+			@apply right-4 bottom-12;
 		}
 	}
 

--- a/src/lib/components/credits/Credits.svelte
+++ b/src/lib/components/credits/Credits.svelte
@@ -33,7 +33,7 @@
 		<button
 			type="button"
 			class="flex h-[29px] w-[29px] items-center justify-center bg-white transition-colors hover:bg-slate-50"
-			on:click={toggleCredits}
+			onclick={toggleCredits}
 			aria-label={ui.creditsExpanded ? 'Collapse credits' : 'Expand credits'}
 		>
 			<svg

--- a/src/lib/components/legend/ExpandLegend.svelte
+++ b/src/lib/components/legend/ExpandLegend.svelte
@@ -11,7 +11,7 @@
 >
 	<button
 		class="flex h-8 items-center justify-center gap-1 px-2"
-		on:click={onClick}
+		onclick={onClick}
 		aria-label="Expand legend"
 	>
 		<svg

--- a/src/lib/utils/config.ts
+++ b/src/lib/utils/config.ts
@@ -106,7 +106,7 @@ export const LAYER_CONFIG: Record<string, AddLayerObject> = {
 		},
 		paint: {
 			'line-color': '#ffffff',
-			'line-width': ['interpolate', ['linear'], ['zoom'], 8, 0.5, 12, 1.5],
+			'line-width': ['interpolate', ['linear'], ['zoom'], 8, 0.25, 12, 1],
 			'line-opacity': 0.8
 		}
 	},
@@ -137,7 +137,7 @@ export const LAYER_CONFIG: Record<string, AddLayerObject> = {
 		},
 		paint: {
 			'line-color': '#ffffff',
-			'line-width': ['interpolate', ['linear'], ['zoom'], 8, 0.5, 12, 1.5],
+			'line-width': ['interpolate', ['linear'], ['zoom'], 8, 0.5, 12, 1],
 			'line-opacity': 0.8
 		}
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { ui } from '$lib/state/ui.svelte';
-	import { searchState, selectedAddressTractId } from '$lib/stores';
-	import { visualization } from '$lib/state/visualization.svelte';
-	import { TABLET_BREAKPOINT } from '$lib/utils/constants';
 	import maplibregl from 'maplibre-gl';
 	import * as pmtiles from 'pmtiles';
+	import { onMount } from 'svelte';
 
-	import { TractPopup } from '$lib/utils/popup';
-	import SearchPanel from '$lib/components/search/SearchPanel.svelte';
+	import Credits from '$lib/components/credits/Credits.svelte';
+	import ExpandLegend from '$lib/components/legend/ExpandLegend.svelte';
 	import Legend from '$lib/components/legend/Legend.svelte';
+	import SearchPanel from '$lib/components/search/SearchPanel.svelte';
+	import { ui } from '$lib/state/ui.svelte';
+	import { visualization } from '$lib/state/visualization.svelte';
+	import { searchState, selectedAddressTractId } from '$lib/stores';
 	import {
 		SOURCE_CONFIG,
 		LAYER_CONFIG,
@@ -18,9 +18,9 @@
 		getChoroplethColorExpression,
 		getQuantileExpression
 	} from '$lib/utils/config';
+	import { TABLET_BREAKPOINT } from '$lib/utils/constants';
+	import { TractPopup } from '$lib/utils/popup';
 	import { fetchQuantileData } from '$lib/utils/quantiles';
-	import ExpandLegend from '$lib/components/legend/ExpandLegend.svelte';
-	import Credits from '$lib/components/credits/Credits.svelte';
 
 	// State.
 	let map = $state<maplibregl.Map | null>(null);
@@ -139,8 +139,7 @@
 					center: isTabletOrAbove ? [-87.7298, 41.84] : [-87.7, 42.02],
 					zoom: isTabletOrAbove ? 10 : 9,
 					minZoom: 8,
-					maxZoom: 18,
-					attributionControl: false
+					maxZoom: 18
 				});
 
 				map.scrollZoom.disable();
@@ -163,17 +162,17 @@
 
 					try {
 						if (!m.getLayer(LAYER_CONFIG.censusTractsFill.id)) {
-							m.addLayer(LAYER_CONFIG.censusTractsFill);
+							m.addLayer(LAYER_CONFIG.censusTractsFill, 'road-label-simple');
 							const choroplethExpression = getChoroplethColorExpression(
 								visualization.choroplethMode
 							);
 							m.setPaintProperty('census-tracts-fill', 'fill-color', choroplethExpression);
 						}
 						if (!m.getLayer(LAYER_CONFIG.censusTractsStroke.id)) {
-							m.addLayer(LAYER_CONFIG.censusTractsStroke);
+							m.addLayer(LAYER_CONFIG.censusTractsStroke, 'road-label-simple');
 						}
 						if (!m.getLayer(LAYER_CONFIG.communityAreasFill.id)) {
-							m.addLayer(LAYER_CONFIG.communityAreasFill);
+							m.addLayer(LAYER_CONFIG.communityAreasFill, 'road-label-simple');
 							const isCommMode = visualization.aggregationLevel === 'community';
 							m.setPaintProperty('community-areas-fill', 'fill-opacity', isCommMode ? 0.7 : 0);
 
@@ -185,7 +184,7 @@
 							}
 						}
 						if (!m.getLayer(LAYER_CONFIG.communityAreasStroke.id)) {
-							m.addLayer(LAYER_CONFIG.communityAreasStroke);
+							m.addLayer(LAYER_CONFIG.communityAreasStroke, 'road-label-simple');
 							const isCommMode = visualization.aggregationLevel === 'community';
 							m.setPaintProperty('community-areas-stroke', 'line-opacity', isCommMode ? 0.8 : 0);
 						}
@@ -265,7 +264,6 @@
 					});
 
 					if (!isTabletOrAbove) {
-						m.addControl(new maplibregl.AttributionControl({ compact: true }), 'bottom-right');
 						const attrib = document.querySelector('.maplibregl-ctrl-attrib');
 						attrib?.classList.remove('maplibregl-compact-show');
 						attrib?.removeAttribute('open');

--- a/styles/map-style.json
+++ b/styles/map-style.json
@@ -1505,7 +1505,7 @@
               "secondary",
               "tertiary"
             ],
-            "hsl(0, 0%, 100%)",
+            "hsl(0, 0%, 85%)",
             "hsl(0, 1%, 100%)"
           ],
           6,
@@ -1518,7 +1518,7 @@
             [
               "motorway"
             ],
-            "hsl(0, 0%, 46%)",
+            "hsl(0, 0%, 85%)",
             "hsl(0, 0%, 100%)"
           ],
           9,
@@ -1531,7 +1531,7 @@
             [
               "motorway"
             ],
-            "hsl(0, 0%, 46%)",
+            "hsl(0, 0%, 85%)",
             "hsl(0, 0%, 100%)"
           ],
           22,
@@ -1546,8 +1546,8 @@
               "secondary",
               "tertiary"
             ],
-            "hsl(0, 0%, 59%)",
-            "hsl(0, 0%, 62%)"
+            "hsl(0, 0%, 85%)",
+            "hsl(0, 0%, 85%)"
           ]
         ],
         "line-width": [
@@ -1865,7 +1865,7 @@
               "trunk",
               "primary"
             ],
-            "hsl(0, 0%, 100%)",
+            "hsl(0, 0%, 85%)",
             "hsl(0, 1%, 100%)"
           ],
           7,
@@ -1879,7 +1879,7 @@
               "motorway",
               "trunk"
             ],
-            "hsl(0, 0%, 59%)",
+            "hsl(0, 0%, 85%)",
             "hsl(0, 0%, 100%)"
           ],
           9,
@@ -1896,7 +1896,7 @@
               "primary",
               "secondary"
             ],
-            "hsl(0, 0%, 59%)",
+            "hsl(0, 0%, 85%)",
             "hsl(0, 0%, 100%)"
           ],
           10,
@@ -1912,8 +1912,8 @@
               "trunk",
               "trunk_link"
             ],
-            "hsl(0, 0%, 46%)",
-            "hsl(0, 0%, 59%)"
+            "hsl(0, 0%, 85%)",
+            "hsl(0, 0%, 85%)"
           ],
           22,
           [
@@ -1928,8 +1928,8 @@
               "service",
               "track"
             ],
-            "hsl(0, 0%, 59%)",
-            "hsl(0, 0%, 62%)"
+            "hsl(0, 0%, 85%)",
+            "hsl(0, 0%, 85%)"
           ]
         ],
         "line-width": [
@@ -4200,127 +4200,10 @@
         ]
       },
       "paint": {
-        "text-color": "hsl(0,0%, 0%)",
+        "text-color": "hsl(0, 0%, 0%)",
         "text-halo-color": "hsl(0, 0%, 100%)",
-        "text-halo-width": 1.5
-      }
-    },
-    {
-      "id": "road-number-shield",
-      "type": "symbol",
-      "source": "stamen-omt",
-      "source-layer": "transportation_name",
-      "minzoom": 9.5,
-      "filter": [
-        "all",
-        [
-          "<=",
-          [
-            "get",
-            "ref_length"
-          ],
-          6
-        ],
-        [
-          "match",
-          [
-            "get",
-            "class"
-          ],
-          [
-            "pedestrian",
-            "service",
-            "motorway_link"
-          ],
-          false,
-          true
-        ]
-      ],
-      "layout": {
-        "icon-image": [
-          "match",
-          [
-            "get",
-            "network"
-          ],
-          [
-            "us-interstate",
-            "us-highway"
-          ],
-          [
-            "concat",
-            "shield-",
-            [
-              "get",
-              "network"
-            ],
-            "-",
-            [
-              "to-string",
-              [
-                "get",
-                "ref_length"
-              ]
-            ]
-          ],
-          [
-            "concat",
-            "shield-rectangle-white",
-            "-",
-            [
-              "to-string",
-              [
-                "get",
-                "ref_length"
-              ]
-            ]
-          ]
-        ],
-        "icon-rotation-alignment": "viewport",
-        "symbol-placement": "line",
-        "symbol-spacing": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          11,
-          400,
-          14,
-          600
-        ],
-        "text-field": [
-          "get",
-          "ref"
-        ],
-        "text-font": [
-          "Basis Grotesque Pro Bold"
-        ],
-        "text-letter-spacing": 0.05,
-        "text-max-angle": 38,
-        "text-rotation-alignment": "viewport",
-        "text-size": 9
-      },
-      "paint": {
-        "text-color": [
-          "case",
-          [
-            "match",
-            [
-              "get",
-              "network"
-            ],
-            [
-              "us-interstate"
-            ],
-            true,
-            false
-          ],
-          "hsl(0, 0%, 100%)",
-          "hsl(230, 11%, 13%)"
-        ]
+        "text-halo-blur": 0.8,
+        "text-halo-width": 0.4
       }
     },
     {
@@ -4775,235 +4658,6 @@
       }
     },
     {
-      "id": "water-point-label",
-      "type": "symbol",
-      "source": "stamen-omt",
-      "source-layer": "water_name",
-      "minzoom": 1,
-      "filter": [
-        "all",
-        [
-          "step",
-          [
-            "zoom"
-          ],
-          [
-            "==",
-            [
-              "get",
-              "class"
-            ],
-            "ocean"
-          ],
-          3,
-          [
-            "match",
-            [
-              "get",
-              "class"
-            ],
-            [
-              "ocean",
-              "sea"
-            ],
-            true,
-            false
-          ],
-          7,
-          [
-            "match",
-            [
-              "get",
-              "class"
-            ],
-            [
-              "lake",
-              "sea",
-              "ocean"
-            ],
-            true,
-            false
-          ]
-        ],
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name_en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Basis Grotesque Pro Italic"
-        ],
-        "text-letter-spacing": [
-          "match",
-          [
-            "get",
-            "class"
-          ],
-          "ocean",
-          0.25,
-          [
-            "bay",
-            "sea"
-          ],
-          0.15,
-          0.1
-        ],
-        "text-line-height": 1.1,
-        "text-max-width": [
-          "match",
-          [
-            "get",
-            "class"
-          ],
-          "ocean",
-          8,
-          [
-            "sea",
-            "bay",
-            "lake"
-          ],
-          7,
-          10
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          1,
-          13,
-          2,
-          [
-            "match",
-            [
-              "get",
-              "class"
-            ],
-            [
-              "ocean"
-            ],
-            15,
-            12
-          ],
-          9,
-          [
-            "match",
-            [
-              "get",
-              "class"
-            ],
-            [
-              "ocean",
-              "sea"
-            ],
-            25,
-            12
-          ],
-          22,
-          14
-        ]
-      },
-      "paint": {
-        "text-color": "hsl(209, 33%, 45%)",
-        "text-halo-color": "hsl(209, 33%, 70%)",
-        "text-halo-width": 1.5
-      }
-    },
-    {
-      "id": "park-label",
-      "type": "symbol",
-      "source": "stamen-omt",
-      "source-layer": "poi",
-      "minzoom": 12.5,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "get",
-            "subclass"
-          ],
-          "park"
-        ],
-        [
-          "step",
-          [
-            "zoom"
-          ],
-          [
-            "any",
-            [
-              "has",
-              "name:ru"
-            ],
-            [
-              "has",
-              "name:zh"
-            ],
-            [
-              "has",
-              "name:kn"
-            ]
-          ],
-          16,
-          true
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "get",
-          "name"
-        ],
-        "text-font": [
-          "Basis Grotesque Pro Regular"
-        ],
-        "text-max-width": 6,
-        "text-size": [
-          "case",
-          [
-            "any",
-            [
-              "has",
-              "name:ru"
-            ],
-            [
-              "has",
-              "name:zh"
-            ],
-            [
-              "has",
-              "name:kn"
-            ]
-          ],
-          20,
-          17
-        ]
-      },
-      "paint": {
-        "text-color": "hsl(90, 13%, 40%)",
-        "text-halo-color": "hsl(64, 32%, 79%)",
-        "text-halo-width": 2
-      }
-    },
-    {
       "id": "airport-label",
       "type": "symbol",
       "source": "stamen-omt",
@@ -5156,7 +4810,7 @@
       "type": "symbol",
       "source": "stamen-omt",
       "source-layer": "place",
-      "minzoom": 10,
+      "minzoom": 11,
       "maxzoom": 14,
       "filter": [
         "all",
@@ -5261,7 +4915,7 @@
       },
       "paint": {
         "text-color": "hsl(0, 2%, 16%)",
-        "text-halo-blur": 1,
+        "text-halo-blur": 0.75,
         "text-halo-color": [
           "interpolate",
           [
@@ -5275,7 +4929,7 @@
           5,
           "hsla(0, 0%, 100%, 1.0)"
         ],
-        "text-halo-width": 1.5
+        "text-halo-width": 1.25
       }
     },
     {
@@ -5750,237 +5404,6 @@
           "hsla(0, 0%, 100%, 1.0)"
         ],
         "text-halo-width": 1.5
-      }
-    },
-    {
-      "id": "continent-label",
-      "type": "symbol",
-      "source": "stamen-omt",
-      "source-layer": "place",
-      "minzoom": 0,
-      "maxzoom": 1.5,
-      "filter": [
-        "match",
-        [
-          "get",
-          "class"
-        ],
-        [
-          "continent"
-        ],
-        true,
-        false
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name_en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Basis Grotesque Pro Bold"
-        ],
-        "text-letter-spacing": 0.2,
-        "text-line-height": 1,
-        "text-max-width": 6,
-        "text-radial-offset": [
-          "step",
-          [
-            "zoom"
-          ],
-          0.6,
-          8,
-          0
-        ],
-        "text-size": 20,
-        "text-transform": "uppercase"
-      },
-      "paint": {
-        "text-color": "hsl(0, 0%, 15%)",
-        "text-halo-color": "hsla(0, 0%, 100%, 0.5)",
-        "text-halo-width": 1.5
-      }
-    },
-    {
-      "id": "country-label",
-      "type": "symbol",
-      "source": "stamen-omt",
-      "source-layer": "place",
-      "minzoom": 1.5,
-      "maxzoom": 5.5,
-      "filter": [
-        "match",
-        [
-          "get",
-          "class"
-        ],
-        [
-          "country",
-          "disputed_country"
-        ],
-        true,
-        false
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name_en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Basis Grotesque Pro Bold"
-        ],
-        "text-letter-spacing": 0.2,
-        "text-line-height": 1,
-        "text-max-width": 6,
-        "text-radial-offset": [
-          "step",
-          [
-            "zoom"
-          ],
-          0.6,
-          8,
-          0
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          1.5,
-          14,
-          5.5,
-          28
-        ],
-        "text-transform": "uppercase"
-      },
-      "paint": {
-        "text-color": "hsl(0, 0%, 15%)",
-        "text-halo-color": "hsla(0, 0%, 100%, 0.5)",
-        "text-halo-width": 1.5
-      }
-    },
-    {
-      "id": "subnational-label",
-      "type": "symbol",
-      "source": "stamen-omt",
-      "source-layer": "place",
-      "minzoom": 3,
-      "maxzoom": 7,
-      "filter": [
-        "match",
-        [
-          "get",
-          "class"
-        ],
-        [
-          "state",
-          "disputed_state"
-        ],
-        true,
-        false
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name_en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Basis Grotesque Pro Bold"
-        ],
-        "text-letter-spacing": 0.15,
-        "text-max-width": 6,
-        "text-size": [
-          "interpolate",
-          [
-            "cubic-bezier",
-            0.85,
-            0.7,
-            0.65,
-            1
-          ],
-          [
-            "zoom"
-          ],
-          4,
-          [
-            "step",
-            [
-              "get",
-              "rank"
-            ],
-            9,
-            6,
-            8,
-            7,
-            7
-          ],
-          7,
-          [
-            "step",
-            [
-              "get",
-              "rank"
-            ],
-            21,
-            6,
-            16,
-            7,
-            14
-          ]
-        ],
-        "text-transform": "uppercase"
-      },
-      "paint": {
-        "text-color": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          3,
-          "hsl(0, 2%, 0%)",
-          5,
-          "hsl(0, 2%, 25%)"
-        ],
-        "text-halo-color": "hsla(0, 0%, 100%, 0.85)",
-        "text-halo-width": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          4,
-          0.75,
-          5,
-          1.75
-        ]
       }
     }
   ]


### PR DESCRIPTION
This PR introduces a new basemap style to improve the visual hierarchy of the map.

| Before | After |
|--------|--------|
| <img width="3104" height="1974" alt="The map before the changes in this pull request." src="https://github.com/user-attachments/assets/61ad6f84-2bec-4e07-90ca-a16d6fbe5bbc" /> | <img width="3104" height="1974" alt="The map after the changes in this pull request." src="https://github.com/user-attachments/assets/2f8e10b7-1bc4-4b66-ba1c-cda75fd0d163" /> |

And at a closer zoom:

| Before | After |
|--------|--------|
| <img width="3104" height="1974" alt="The map before the changes in this pull request." src="https://github.com/user-attachments/assets/c861711d-87ee-4f52-8f6b-e3f84375650f" /> | <img width="3104" height="1974" alt="The map after the changes in this pull request." src="https://github.com/user-attachments/assets/ed581bf6-051c-4342-815e-fc86b5a4e897" /> | 

The key highlights are:

- I removed the Interstate shields—not really pertinent for a within-city story
- I upped the lightness on the road network so it fades more into the base layer
- Neighborhood labels are rendered at zoom level 11 so they don’t clutter the initial view
- This next one is the biggie—labels are rendered above the data layer rather than below. This makes it much easier to identify streets at close zooms (more screenshots incoming).
- The strokes on Census tracts and community areas are thinned by 0.5px at higher zooms.

Change 4 is the only one that required a code change—we use the third argument (`beforeId`) of the [`map.addLayer`](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#addlayer) API to add the data layers _before_ (beneath) the road labels.