### PR TITLE
feat: Add Spanish translation copy and restructure ServiceLineDiagram and SocialState to accommodate variable length text.

### DIFF
--- a/src/lib/components/data/ServiceLineDetails.svelte
+++ b/src/lib/components/data/ServiceLineDetails.svelte
@@ -2,8 +2,8 @@
 	import { getContext } from 'svelte';
 
 	import { messages as i18nMessages, type Language } from '$lib/i18n/messages';
-	import ServiceLineDiagram from '$lib/components/search/ServiceLineDiagram.svelte';
-	import ServiceLineDiagramLoading from '$lib/components/search/ServiceLineDiagramLoading.svelte';
+	import ServiceLineDiagram from '$lib/components/service-line/ServiceLineDiagram.svelte';
+	import ServiceLineDiagramLoading from '$lib/components/service-line/ServiceLineDiagramLoading.svelte';
 	import {
 		multiServiceLineStore,
 		serviceLineCount,

--- a/src/lib/components/search/SearchPanel.svelte
+++ b/src/lib/components/search/SearchPanel.svelte
@@ -4,7 +4,7 @@
 	import { getContext } from 'svelte';
 
 	import SearchSuggestions from '$lib/components/search/SearchSuggestions.svelte';
-	import ServiceLineResults from '$lib/components/search/ServiceLineResults.svelte';
+	import ServiceLineResults from '$lib/components/service-line/ServiceLineResults.svelte';
 	import { messages as i18nMessages, type Language } from '$lib/i18n/messages';
 	import { search } from '$lib/state/search.svelte';
 	import { ui } from '$lib/state/ui.svelte';
@@ -242,11 +242,11 @@
 				// Check if the query number matches this address
 				// For single addresses (n2 === 0), match exact number
 				// For range addresses (n2 > 0), check if number is in range
-				const numberMatches = addr.n1 > 0 && (
-					(addr.n2 === 0 && queryNumber === addr.n1) ||
-					(addr.n2 > 0 && queryNumber >= addr.n1 && queryNumber <= addr.n2)
-				);
-				
+				const numberMatches =
+					addr.n1 > 0 &&
+					((addr.n2 === 0 && queryNumber === addr.n1) ||
+						(addr.n2 > 0 && queryNumber >= addr.n1 && queryNumber <= addr.n2));
+
 				if (numberMatches) {
 					// Only match against the street portion of the address, not the city
 					// addr.a is already in the format "1234 N CHICAGO AVE, 60601" or similar
@@ -547,11 +547,11 @@
 				// Check if query number matches this address
 				// For single addresses (num2 === 0), match exact number
 				// For range addresses (num2 > 0), check if number is in range
-				const numberMatches = addr.num1 > 0 && (
-					(addr.num2 === 0 && queryNumber === addr.num1) ||
-					(addr.num2 > 0 && queryNumber >= addr.num1 && queryNumber <= addr.num2)
-				);
-				
+				const numberMatches =
+					addr.num1 > 0 &&
+					((addr.num2 === 0 && queryNumber === addr.num1) ||
+						(addr.num2 > 0 && queryNumber >= addr.num1 && queryNumber <= addr.num2));
+
 				if (numberMatches) {
 					// Now check if the street part matches
 					// Remove the street number from the display address before normalizing

--- a/src/lib/components/service-line/MaterialLabel.svelte
+++ b/src/lib/components/service-line/MaterialLabel.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+
+	import { messages as i18nMessages, type Language } from '$lib/i18n/messages';
+	import { formatServiceLineMaterial } from '$lib/utils/formatters';
+
+	interface Props {
+		material: string;
+		x: number;
+		y: number;
+	}
+
+	let { material, x, y }: Props = $props();
+
+	// Context.
+	const lang = getContext<() => Language>('lang');
+
+	// State.
+	let messages = $derived(i18nMessages[lang()]);
+	let materialLabel = $derived(splitLabel(material));
+
+	function splitLabel(material: string): { line1: string; line2?: string; line3?: string } {
+		switch (material.toUpperCase()) {
+			case 'C':
+				return {
+					line1: messages.serviceLineInformation.split.copper,
+					line2: messages.serviceLineInformation.split.noLeadSolder
+				};
+			case 'CLS':
+				return {
+					line1: messages.serviceLineInformation.split.copper,
+					line2: messages.serviceLineInformation.split.leadSolder
+				};
+			case 'GRR':
+				return {
+					line1: messages.serviceLineInformation.split.galvanized,
+					line2: messages.serviceLineInformation.split.requiring,
+					line3: messages.serviceLineInformation.split.replacement
+				};
+			case 'O':
+				return {
+					line1: messages.serviceLineInformation.split.castDuctile,
+					line2: messages.serviceLineInformation.split.orTransite
+				};
+			case 'P':
+				return {
+					line1: messages.serviceLineInformation.split.plastic,
+					line2: messages.serviceLineInformation.split.pvchdpepex
+				};
+			case 'UNL':
+				return {
+					line1: messages.serviceLineInformation.split.unknown,
+					line2: messages.serviceLineInformation.split.notLead
+				};
+			default:
+				return {
+					line1: formatServiceLineMaterial(material, { lang: lang() })
+				};
+		}
+	}
+</script>
+
+<text {x} {y} text-anchor="middle" class="fill-earth/80 text-sm font-medium">
+	{materialLabel.line1}
+	{#if materialLabel.line2}
+		<tspan {x} dy="15">{materialLabel.line2}</tspan>
+	{/if}
+	{#if materialLabel.line3}
+		<tspan {x} dy="15">{materialLabel.line3}</tspan>
+	{/if}
+</text>

--- a/src/lib/components/service-line/ServiceLineDiagram.svelte
+++ b/src/lib/components/service-line/ServiceLineDiagram.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 
+	import MaterialLabel from '$lib/components/service-line/MaterialLabel.svelte';
 	import { messages as i18nMessages, type Language } from '$lib/i18n/messages';
 	import { multiServiceLineStore, serviceLineCount } from '$lib/stores';
 	import { COLORS, getMaterialColor } from '$lib/utils/constants';
+	import { formatServiceLineMaterial } from '$lib/utils/formatters';
 
 	interface Props {
 		utilitySideMaterial: string;
@@ -23,89 +25,6 @@
 	let gooseneckColor = $derived(getMaterialColor(gooseneckMaterial));
 	let customerColor = $derived(getMaterialColor(customerSideMaterial));
 	let messages = $derived(i18nMessages[lang()]);
-
-	function getMaterialLabel(material: string): string {
-		if (!material) {
-			return messages.serviceLineInformation.leadStatus.Unknown;
-		}
-
-		switch (material.toUpperCase()) {
-			case 'C':
-				return messages.serviceLineInformation.leadStatus.C;
-			case 'CLS':
-				return messages.serviceLineInformation.leadStatus.CLS;
-			case 'G':
-				return messages.serviceLineInformation.leadStatus.G;
-			case 'GRR':
-				return messages.serviceLineInformation.leadStatus.GRR;
-			case 'L':
-				return messages.serviceLineInformation.leadStatus.L;
-			case 'O':
-				return messages.serviceLineInformation.leadStatus.O;
-			case 'P':
-				return messages.serviceLineInformation.leadStatus.P;
-			case 'U':
-				return messages.serviceLineInformation.leadStatus.U;
-			case 'UNL':
-				return messages.serviceLineInformation.leadStatus.UNL;
-			case 'NL':
-				return messages.serviceLineInformation.leadStatus.NL;
-			default:
-				return material;
-		}
-	}
-
-	function splitLabel(label: string): { line1: string; line2?: string } {
-		if (label.length <= 20) {
-			return { line1: label };
-		}
-
-		switch (label) {
-			case 'Suspected Lead':
-				return {
-					line1: messages.serviceLineInformation.split.unknown,
-					line2: `(${messages.serviceLineInformation.leadStatus.U})`
-				};
-			case 'Unknown (Not Lead)':
-				return {
-					line1: messages.serviceLineInformation.split.unknown,
-					line2: `(${messages.serviceLineInformation.leadStatus.UNL})`
-				};
-			case 'Galvanized Requiring Replacement':
-				return {
-					line1: messages.serviceLineInformation.split.galvanizedRequiring,
-					line2: messages.serviceLineInformation.split.replacement
-				};
-			case 'Cast/Ductile Iron or Transite':
-				return {
-					line1: messages.serviceLineInformation.split.castDuctile,
-					line2: messages.serviceLineInformation.split.orTransite
-				};
-			case 'Copper - No Lead Solder':
-				return {
-					line1: `${messages.serviceLineInformation.split.copper} -`,
-					line2: messages.serviceLineInformation.split.noLeadSolder
-				};
-			case 'Copper - Lead Solder':
-				return {
-					line1: `${messages.serviceLineInformation.split.copper} -`,
-					line2: messages.serviceLineInformation.split.leadSolder
-				};
-			case 'Plastic - PVC, HDPE, PEX':
-				return {
-					line1: `${messages.serviceLineInformation.split.plastic} -`,
-					line2: messages.serviceLineInformation.split.pvchdpepex
-				};
-			default: {
-				const words = label.split(' ');
-				const midpoint = Math.ceil(words.length / 2);
-				return {
-					line1: words.slice(0, midpoint).join(' '),
-					line2: words.slice(midpoint).join(' ')
-				};
-			}
-		}
-	}
 </script>
 
 <!-- Service Line Diagram -->
@@ -133,9 +52,9 @@
 			</text>
 		{:else if overallCode === 'GRR'}
 			<rect
-				x="-120"
+				x={lang() === 'en' ? '-120' : '-150'}
 				y="-12"
-				width="240"
+				width={lang() === 'en' ? '240' : '300'}
 				height="24"
 				fill={getMaterialColor(overallCode)}
 				stroke="#ffffff"
@@ -163,9 +82,9 @@
 			</text>
 		{:else if overallCode === 'U'}
 			<rect
-				x="-65"
+				x={lang() === 'en' ? '-65' : '-75'}
 				y="-12"
-				width="130"
+				width={lang() === 'en' ? '130' : '150'}
 				height="24"
 				fill={getMaterialColor(overallCode)}
 				stroke="#ffffff"
@@ -233,23 +152,66 @@
 	/>
 
 	<!-- Labels -->
-	<text x="40" y="110" text-anchor="middle" class="fill-earth/80 text-sm font-medium"
-		>{messages.serviceLineInformation.components.waterMain}</text
-	>
+	{#if lang() === 'en'}
+		<text x="40" y="110" text-anchor="middle" class="fill-earth/80 text-sm font-medium"
+			>{messages.serviceLineInformation.components.waterMain}</text
+		>
+	{:else}
+		<text x="40" y="105" text-anchor="middle" class="fill-earth/80 text-sm font-medium">
+			<tspan x="41" dy="0"
+				>{messages.serviceLineInformation.components.waterMain.split(' ')[0]}</tspan
+			>
+			<tspan x="40" dy="14"
+				>{messages.serviceLineInformation.components.waterMain.split(' ').slice(1).join(' ')}</tspan
+			>
+		</text>
+	{/if}
 	<text x="140" y="110" text-anchor="middle" class="fill-earth/80 text-sm font-medium"
 		>{messages.serviceLineInformation.components.gooseneck}</text
 	>
 
 	<!-- Utility portion label with text wrapping -->
 	<text x="285" y="105" text-anchor="middle" class="fill-earth/80 text-sm font-medium">
-		<tspan x="285" dy="0">{messages.serviceLineInformation.components.utilityPortion}</tspan>
-		<tspan x="283" dy="14">{messages.serviceLineInformation.components.ofServiceLine}</tspan>
+		{#if lang() === 'en'}
+			<tspan x="285" dy="0">{messages.serviceLineInformation.components.utilityPortion}</tspan>
+			<tspan x="283" dy="14">{messages.serviceLineInformation.components.ofServiceLine}</tspan>
+		{:else}
+			<tspan x="285" dy="0"
+				>{messages.serviceLineInformation.components.utilityPortion
+					.split(' ')
+					.slice(0, 2)
+					.join(' ')}</tspan
+			>
+			<tspan x="285" dy="14"
+				>{messages.serviceLineInformation.components.utilityPortion
+					.split(' ')
+					.slice(2)
+					.join(' ')}</tspan
+			>
+			<tspan x="283" dy="14">{messages.serviceLineInformation.components.ofServiceLine}</tspan>
+		{/if}
 	</text>
 
 	<!-- Customer portion label with text wrapping -->
 	<text x="450" y="105" text-anchor="middle" class="fill-earth/80 text-sm font-medium">
-		<tspan x="442" dy="0">{messages.serviceLineInformation.components.customerPortion}</tspan>
-		<tspan x="442" dy="14">{messages.serviceLineInformation.components.ofServiceLine}</tspan>
+		{#if lang() === 'en'}
+			<tspan x="442" dy="0">{messages.serviceLineInformation.components.customerPortion}</tspan>
+			<tspan x="442" dy="14">{messages.serviceLineInformation.components.ofServiceLine}</tspan>
+		{:else}
+			<tspan x="442" dy="0">{messages.serviceLineInformation.components.customerPortion}</tspan>
+			<tspan x="442" dy="14"
+				>{messages.serviceLineInformation.components.ofServiceLine
+					.split(' ')
+					.slice(0, 3)
+					.join(' ')}</tspan
+			>
+			<tspan x="442" dy="14"
+				>{messages.serviceLineInformation.components.ofServiceLine
+					.split(' ')
+					.slice(3)
+					.join(' ')}</tspan
+			>
+		{/if}
 	</text>
 
 	<!-- Water main (Circle on far left) -->
@@ -268,8 +230,9 @@
 			stroke-linecap="round"
 		>
 			<title
-				>{messages.serviceLineInformation.components.gooseneck}: {getMaterialLabel(
-					gooseneckMaterial
+				>{messages.serviceLineInformation.components.gooseneck}: {formatServiceLineMaterial(
+					gooseneckMaterial,
+					{ lang: lang() }
 				)}</title
 			>
 		</path>
@@ -305,8 +268,9 @@
 		rx="4"
 	>
 		<title
-			>{messages.serviceLineInformation.components.utilitySide}: {getMaterialLabel(
-				utilitySideMaterial
+			>{messages.serviceLineInformation.components.utilitySide}: {formatServiceLineMaterial(
+				utilitySideMaterial,
+				{ lang: lang() }
 			)}</title
 		>
 	</rect>
@@ -323,35 +287,13 @@
 		rx="4"
 	>
 		<title
-			>{messages.serviceLineInformation.components.customerSide}: {getMaterialLabel(
-				customerSideMaterial
+			>{messages.serviceLineInformation.components.customerSide}: {formatServiceLineMaterial(
+				customerSideMaterial,
+				{ lang: lang() }
 			)}</title
 		>
 	</rect>
-
-	<!-- Material labels below pipes with text wrapping -->
-	<text x="140" y="200" text-anchor="middle" class="fill-earth/80 text-sm font-medium">
-		{#if splitLabel(getMaterialLabel(gooseneckMaterial)).line2}
-			<tspan x="140" dy="0">{splitLabel(getMaterialLabel(gooseneckMaterial)).line1}</tspan>
-			<tspan x="140" dy="15">{splitLabel(getMaterialLabel(gooseneckMaterial)).line2}</tspan>
-		{:else}
-			{getMaterialLabel(gooseneckMaterial)}
-		{/if}
-	</text>
-	<text x="285" y="200" text-anchor="middle" class="fill-earth/80 text-sm font-medium">
-		{#if splitLabel(getMaterialLabel(utilitySideMaterial)).line2}
-			<tspan x="285" dy="0">{splitLabel(getMaterialLabel(utilitySideMaterial)).line1}</tspan>
-			<tspan x="285" dy="15">{splitLabel(getMaterialLabel(utilitySideMaterial)).line2}</tspan>
-		{:else}
-			{getMaterialLabel(utilitySideMaterial)}
-		{/if}
-	</text>
-	<text x="440" y="200" text-anchor="middle" class="fill-earth/80 text-sm font-medium">
-		{#if splitLabel(getMaterialLabel(customerSideMaterial)).line2}
-			<tspan x="440" dy="0">{splitLabel(getMaterialLabel(customerSideMaterial)).line1}</tspan>
-			<tspan x="440" dy="15">{splitLabel(getMaterialLabel(customerSideMaterial)).line2}</tspan>
-		{:else}
-			{getMaterialLabel(customerSideMaterial)}
-		{/if}
-	</text>
+	<MaterialLabel material={gooseneckMaterial} x={140} y={200} />
+	<MaterialLabel material={utilitySideMaterial} x={285} y={200} />
+	<MaterialLabel material={customerSideMaterial} x={440} y={200} />
 </svg>

--- a/src/lib/components/service-line/ServiceLineDiagramLoading.svelte
+++ b/src/lib/components/service-line/ServiceLineDiagramLoading.svelte
@@ -53,10 +53,10 @@
 
 	<!-- Public/Customer Side Headers -->
 	<text x="200" y="80" text-anchor="middle" class="fill-earth/40 text-sm font-semibold"
-		>Public Side</text
+		>{messages.serviceLineInformation.components.publicSide}</text
 	>
 	<text x="440" y="80" text-anchor="middle" class="fill-earth/40 text-sm font-semibold"
-		>Private Side</text
+		>{messages.serviceLineInformation.components.privateSide}</text
 	>
 
 	<!-- Dividing line between public and customer sides -->
@@ -72,23 +72,66 @@
 	/>
 
 	<!-- Labels -->
-	<text x="40" y="110" text-anchor="middle" class="fill-earth/40 text-sm font-medium"
-		>{messages.serviceLineInformation.components.waterMain}</text
-	>
+	{#if lang() === 'en'}
+		<text x="40" y="110" text-anchor="middle" class="fill-earth/40 text-sm font-medium"
+			>{messages.serviceLineInformation.components.waterMain}</text
+		>
+	{:else}
+		<text x="40" y="105" text-anchor="middle" class="fill-earth/40 text-sm font-medium">
+			<tspan x="41" dy="0"
+				>{messages.serviceLineInformation.components.waterMain.split(' ')[0]}</tspan
+			>
+			<tspan x="40" dy="14"
+				>{messages.serviceLineInformation.components.waterMain.split(' ').slice(1).join(' ')}</tspan
+			>
+		</text>
+	{/if}
 	<text x="140" y="110" text-anchor="middle" class="fill-earth/40 text-sm font-medium"
 		>{messages.serviceLineInformation.components.gooseneck}</text
 	>
 
 	<!-- Utility portion label with text wrapping -->
 	<text x="285" y="105" text-anchor="middle" class="fill-earth/40 text-sm font-medium">
-		<tspan x="285" dy="0">{messages.serviceLineInformation.components.utilityPortion}</tspan>
-		<tspan x="283" dy="14">{messages.serviceLineInformation.components.ofServiceLine}</tspan>
+		{#if lang() === 'en'}
+			<tspan x="285" dy="0">{messages.serviceLineInformation.components.utilityPortion}</tspan>
+			<tspan x="283" dy="14">{messages.serviceLineInformation.components.ofServiceLine}</tspan>
+		{:else}
+			<tspan x="285" dy="0"
+				>{messages.serviceLineInformation.components.utilityPortion
+					.split(' ')
+					.slice(0, 2)
+					.join(' ')}</tspan
+			>
+			<tspan x="285" dy="14"
+				>{messages.serviceLineInformation.components.utilityPortion
+					.split(' ')
+					.slice(2)
+					.join(' ')}</tspan
+			>
+			<tspan x="283" dy="14">{messages.serviceLineInformation.components.ofServiceLine}</tspan>
+		{/if}
 	</text>
 
 	<!-- Customer portion label with text wrapping -->
 	<text x="450" y="105" text-anchor="middle" class="fill-earth/40 text-sm font-medium">
-		<tspan x="442" dy="0">{messages.serviceLineInformation.components.customerPortion}</tspan>
-		<tspan x="442" dy="14">{messages.serviceLineInformation.components.ofServiceLine}</tspan>
+		{#if lang() === 'en'}
+			<tspan x="442" dy="0">{messages.serviceLineInformation.components.customerPortion}</tspan>
+			<tspan x="442" dy="14">{messages.serviceLineInformation.components.ofServiceLine}</tspan>
+		{:else}
+			<tspan x="442" dy="0">{messages.serviceLineInformation.components.customerPortion}</tspan>
+			<tspan x="442" dy="14"
+				>{messages.serviceLineInformation.components.ofServiceLine
+					.split(' ')
+					.slice(0, 3)
+					.join(' ')}</tspan
+			>
+			<tspan x="442" dy="14"
+				>{messages.serviceLineInformation.components.ofServiceLine
+					.split(' ')
+					.slice(3)
+					.join(' ')}</tspan
+			>
+		{/if}
 	</text>
 
 	<!-- Define gradient for water flow -->

--- a/src/lib/components/service-line/ServiceLineResults.svelte
+++ b/src/lib/components/service-line/ServiceLineResults.svelte
@@ -160,7 +160,7 @@
 					</div>
 				</div>
 			{:else}
-				<div class="flex items-center gap-1 sm:gap-2">
+				<div class="flex items-center gap-1 self-start sm:gap-2">
 					<span class="text-earth text-xs sm:text-sm"
 						>{messages.selectedAddress.leadStatus.label}:</span
 					>
@@ -188,14 +188,14 @@
 						</span>
 					{:else if displayCode === 'L' || displayCode === 'GRR' || displayCode === 'NL'}
 						<span
-							class="inline-flex items-center self-start rounded-full border-2 border-white px-2 py-0.5 text-xs font-medium text-white sm:px-2.5 sm:text-sm"
+							class="inline-flex items-center rounded-full border-2 border-white px-2 py-0.5 text-center text-xs font-medium text-white sm:px-2.5 sm:text-sm"
 							style="background-color: {getMaterialColor(displayCode)}"
 						>
 							{messages.selectedAddress.leadStatus[displayCode]}
 						</span>
 					{:else}
 						<span
-							class="inline-flex items-center self-start rounded-full border-2 border-white px-2 py-0.5 text-xs font-medium text-white sm:px-2.5 sm:text-sm"
+							class="inline-flex items-center rounded-full border-2 border-white px-2 py-0.5 text-center text-xs font-medium text-white sm:px-2.5 sm:text-sm"
 							style="background-color: {getMaterialColor('U')}"
 						>
 							{messages.selectedAddress.leadStatus.U}
@@ -204,7 +204,7 @@
 					{#if !isLoading}
 						<button
 							onclick={shareResults}
-							class="inline-flex cursor-pointer items-center self-start rounded-full border-2 border-white px-2 py-0.5 text-xs font-medium text-white transition-opacity hover:opacity-90 sm:px-2.5 sm:text-sm"
+							class="inline-flex cursor-pointer items-center rounded-full border-2 border-white px-2 py-0.5 text-xs font-medium text-white transition-opacity hover:opacity-90 sm:px-2.5 sm:text-sm"
 							style="background-color: {COLORS.EARTH}"
 							title="Share your results"
 						>

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -439,8 +439,8 @@ export const messages: Record<Language, Messages> = {
 			title: 'Selecciona una capa de datos para visualizarla',
 			aggregationLevel: {
 				label: 'Nivel de agregación',
-				censusTractsButton: 'Áreas comunitarias',
-				communityAreasButton: 'Tramos del Censo'
+				censusTractsButton: 'Tramos del Censo',
+				communityAreasButton: 'Áreas comunitarias'
 			},
 			dataVisualization: {
 				label: 'Visualización de datos',
@@ -455,9 +455,9 @@ export const messages: Record<Language, Messages> = {
 			},
 			annotation: {
 				censusTracts:
-					'Los cuadros de color tienen un tamaño proporcional al número de áreas comunitarias que contienen, y se ofrecen detalles más pequeños en cada extremo del rango.',
+					'Los cuadros de color tienen un tamaño proporcional al número de tramos del Censo que contienen, y se ofrecen detalles más pequeños en cada extremo del rango.',
 				communityAreas:
-					'Los cuadros de color tienen un tamaño proporcional al número de tramos del Censo que contienen, y se ofrecen detalles más pequeños en cada extremo del rango.'
+					'Los cuadros de color tienen un tamaño proporcional al número de áreas comunitarias que contienen, y se ofrecen detalles más pequeños en cada extremo del rango.'
 			},
 			loading: 'Cargando...'
 		},

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -421,7 +421,7 @@ export const messages: Record<Language, Messages> = {
 				'No se encontraron resultados de inventario. Se muestra un resultado generalizado de la dirección:'
 		},
 		credits: {
-			importantInformation: 'Información importante',
+			importantInformation: 'Información Importante',
 			dataDisclaimer:
 				'Los datos están actualizados según el inventario de líneas de servicio de agua de la ciudad en 2025. Los datos municipales están incompletos y podrían contener inexactitudes y repeticiones. Es posible que varias direcciones reciban el servicio de la misma línea de servicio. Algunas direcciones aparecerán como rangos. Recomendamos a los usuarios que verifiquen la información de forma independiente antes de tomar decisiones.',
 			sources: 'Fuentes',
@@ -464,12 +464,12 @@ export const messages: Record<Language, Messages> = {
 		selectedAddress: {
 			label: 'Dirección seleccionada',
 			leadStatus: {
-				label: 'Estado de plomo',
+				label: 'Estado de Plomo',
 				loading: 'Cargando...',
 				L: 'Plomo',
-				GRR: 'Acero galvanizado (Reemplazar)',
-				NL: 'Sin plomo',
-				U: 'Sospecha de plomo'
+				GRR: 'Acero Galvanizado (Reemplazar)',
+				NL: 'Sin Plomo',
+				U: 'Sospecha de Plomo'
 			},
 			addressNotFound:
 				'La dirección que buscas no figura en el inventario de líneas de agua de la Ciudad de Chicago. Sin embargo, puedes hacer clic en una línea de servicio cercana para ver su condición.',
@@ -488,7 +488,7 @@ export const messages: Record<Language, Messages> = {
 			loading: 'Cargando información de la línea de servicio...',
 			linesFound: 'líneas en esta dirección',
 			leadStatus: {
-				label: 'Estado de plomo',
+				label: 'Estado de Plomo',
 				loading: 'Cargando...',
 				C: 'Cobre - Soldadura sin Plomo',
 				CLS: 'Cobre - Soldadura con Plomo',
@@ -510,8 +510,8 @@ export const messages: Record<Language, Messages> = {
 				utilityPortion: 'Porción de servicio público',
 				customerPortion: 'Porción del cliente',
 				ofServiceLine: 'de la línea de servicio',
-				utilitySide: 'Lado de servicio público',
-				customerSide: 'Lado del cliente de la línea de servicio'
+				utilitySide: 'Lado de Servicio Público',
+				customerSide: 'Lado del Cliente de la Línea de Servicio'
 			},
 			split: {
 				unknown: 'Desconocido',
@@ -555,20 +555,20 @@ export const messages: Record<Language, Messages> = {
 		},
 		serviceLineInventory: {
 			lead: 'Plomo',
-			suspectedLead: 'Sospecha de plomo',
-			galvanizedReplace: 'Acero galvanizado (Reemplazar)',
-			nonLead: 'Sin plomo',
+			suspectedLead: 'Sospecha de Plomo',
+			galvanizedReplace: 'Acero Galvanizado (Reemplazar)',
+			nonLead: 'Sin Plomo',
 			total: 'Total',
-			requiresReplacement: 'Requiere reemplazar'
+			requiresReplacement: 'Requiere Reemplazar'
 		},
 		demographicContext: {
-			medianHouseholdIncome: 'Ingreso promedio',
-			povertyRate: 'Tasa de pobreza',
-			blackPopulation: 'Población afroamericana',
-			latinoPopulation: 'Población latina',
-			whitePopulation: 'Población blanca anglosajona',
-			asianPopulation: 'Población asiática',
-			nonWhitePopulation: 'Población no-blanca anglosajona'
+			medianHouseholdIncome: 'Ingreso Promedio',
+			povertyRate: 'Tasa de Pobreza',
+			blackPopulation: 'Población Afroamericana',
+			latinoPopulation: 'Población Latina',
+			whitePopulation: 'Población Blanca Anglosajona',
+			asianPopulation: 'Población Asiática',
+			nonWhitePopulation: 'Población No-Blanca Anglosajona'
 		},
 		tooltips: {
 			definitions: {
@@ -582,24 +582,24 @@ export const messages: Record<Language, Messages> = {
 			}
 		},
 		resources: {
-			button: 'Recursos para dirección seleccionada',
+			button: 'Recursos para Dirección Seleccionada',
 			title: '¿Qué puedo hacer?',
 			resultDescription: ({ plural }) =>
 				`Según el resultado de su línea de servicio, ${plural ? 'los siguientes recursos están disponibles' : 'el siguiente recurso está disponible'}`,
 			freeWaterTestingKit: {
-				label: 'Kit de pruebas de agua gratuito',
+				label: 'Kit de Pruebas de Agua Gratuito',
 				description:
 					'Todos los residentes de Chicago pueden solicitar un kit de prueba de agua gratuito para verificar los niveles de plomo.',
 				CTA: 'Solicita un kit de pruebas de agua gratis'
 			},
 			freeWaterFilter: {
-				label: 'Filtro de agua gratuito',
+				label: 'Filtro de Agua Gratuito',
 				description:
 					'Verifica si su dirección califica para un filtro de agua gratuito de la ciudad de Chicago.',
 				CTA: 'Inscríbete para un filtro de agua gratis'
 			},
 			leadPipeReplacementAssistance: {
-				label: 'Ayuda para reemplazar las pipas con plomo',
+				label: 'Ayuda para Reemplazar las Pipas con Plomo',
 				description:
 					'Dependiendo de tus ingresos, podrías calificar para el reemplazo gratuito de tuberías de plomo.',
 				CTA: 'Solicita ayuda para reemplazarlas'
@@ -617,9 +617,9 @@ export const messages: Record<Language, Messages> = {
 				serviceLineMadeOf: 'mi línea de servicio de agua',
 				leadStatus: {
 					L: 'Plomo',
-					GRR: 'Acero galvanizado que requiere reemplazo',
-					NL: 'Sin plomo',
-					U: 'Sospecha de plomo',
+					GRR: 'Acero Galvanizado que Requiere Reemplazar',
+					NL: 'Sin Plomo',
+					U: 'Sospecha de Plomo',
 					Unknown: 'Desconocido'
 				},
 				checkYourLeadStatus: 'revisa la condición de plomo de tu hogar'

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -97,7 +97,9 @@ interface Messages {
 		};
 		split: {
 			unknown: string;
-			galvanizedRequiring: string;
+			notLead: string;
+			galvanized: string;
+			requiring: string;
 			replacement: string;
 			castDuctile: string;
 			orTransite: string;
@@ -300,11 +302,13 @@ export const messages: Record<Language, Messages> = {
 			},
 			split: {
 				unknown: 'Unknown',
-				galvanizedRequiring: 'Galvanized Requiring',
+				notLead: '(Not Lead)',
+				galvanized: 'Galvanized',
+				requiring: 'Requiring',
 				replacement: 'Replacement',
 				castDuctile: 'Cast/Ductile Iron',
 				orTransite: 'or Transite',
-				copper: 'Copper',
+				copper: 'Copper -',
 				noLeadSolder: 'No Lead Solder',
 				leadSolder: 'Lead Solder',
 				plastic: 'Plastic',
@@ -409,198 +413,216 @@ export const messages: Record<Language, Messages> = {
 		}
 	},
 	es: {
-		hed: 'TK',
-		dek: 'TK',
+		hed: '¿Las pipas de agua de tu propiedad contienen plomo?',
+		dek: 'Escribe tu dirección para saber si tu línea de servicio de agua necesita ser reemplazada y cómo se compara tu vecindario con otros.',
 		search: {
-			button: 'TK',
-			noResults: 'TK'
+			button: 'Buscar',
+			noResults:
+				'No se encontraron resultados de inventario. Se muestra un resultado generalizado de la dirección:'
 		},
 		credits: {
-			importantInformation: 'TK',
-			dataDisclaimer: 'TK',
-			sources: 'TK',
-			cityOfChicago: 'TK',
-			censusBureau: 'TK',
-			analysis: 'TK',
-			development: 'TK',
-			seeOur: 'TK',
-			methods: 'TK'
+			importantInformation: 'Información importante',
+			dataDisclaimer:
+				'Los datos están actualizados según el inventario de líneas de servicio de agua de la ciudad en 2025. Los datos municipales están incompletos y podrían contener inexactitudes y repeticiones. Es posible que varias direcciones reciban el servicio de la misma línea de servicio. Algunas direcciones aparecerán como rangos. Recomendamos a los usuarios que verifiquen la información de forma independiente antes de tomar decisiones.',
+			sources: 'Fuentes',
+			cityOfChicago: 'Ciudad de Chicago',
+			censusBureau: 'Buró del Censo',
+			analysis: 'Análisis',
+			development: 'Producción',
+			seeOur: 'Ve nuestros',
+			methods: 'métodos'
 		},
 		notes: {
-			button: 'TK'
+			button: 'Notas'
 		},
 		legend: {
-			title: 'TK',
+			title: 'Selecciona una capa de datos para visualizarla',
 			aggregationLevel: {
-				label: 'TK',
-				censusTractsButton: 'TK',
-				communityAreasButton: 'TK'
+				label: 'Nivel de agregación',
+				censusTractsButton: 'Áreas comunitarias',
+				communityAreasButton: 'Tramos del Censo'
 			},
 			dataVisualization: {
-				label: 'TK',
-				leadButton: 'TK',
-				povertyButton: 'TK',
-				raceButton: 'TK'
+				label: 'Visualización de datos',
+				leadButton: 'Plomo',
+				povertyButton: 'Pobreza',
+				raceButton: 'Raza'
 			},
 			variable: {
-				pctRequiresReplacementLabel: 'TK',
-				pctPovertyLabel: 'TK',
-				pctRaceLabel: 'TK'
+				pctRequiresReplacementLabel: 'Porcentaje de líneas de servicio que requieren reemplazo',
+				pctPovertyLabel: 'Porcentaje de población por debajo de la línea de pobreza',
+				pctRaceLabel: 'Porcentaje de población que no es blanca'
 			},
 			annotation: {
-				censusTracts: 'TK',
-				communityAreas: 'TK'
+				censusTracts:
+					'Los cuadros de color tienen un tamaño proporcional al número de áreas comunitarias que contienen, y se ofrecen detalles más pequeños en cada extremo del rango.',
+				communityAreas:
+					'Los cuadros de color tienen un tamaño proporcional al número de tramos del Censo que contienen, y se ofrecen detalles más pequeños en cada extremo del rango.'
 			},
-			loading: 'TK'
+			loading: 'Cargando...'
 		},
 		selectedAddress: {
-			label: 'TK',
+			label: 'Dirección seleccionada',
 			leadStatus: {
-				label: 'TK',
-				loading: 'TK',
-				L: 'TK',
-				GRR: 'TK',
-				NL: 'TK',
-				U: 'TK'
+				label: 'Estado de plomo',
+				loading: 'Cargando...',
+				L: 'Plomo',
+				GRR: 'Acero galvanizado (Reemplazar)',
+				NL: 'Sin plomo',
+				U: 'Sospecha de plomo'
 			},
-			addressNotFound: 'TK',
-			multipleServiceLines: ({ count }) => `TK ${count}`,
+			addressNotFound:
+				'La dirección que buscas no figura en el inventario de líneas de agua de la Ciudad de Chicago. Sin embargo, puedes hacer clic en una línea de servicio cercana para ver su condición.',
+			multipleServiceLines: ({ count }) =>
+				`Esta dirección está asociada con ${count} registros de la línea de servicio. La condición que se muestra arriba representa el peor caso posible en todas las líneas: Si se sospecha la presencia de plomo en alguna de las líneas de servicio, se indicará aquí. Consulta los detalles de cada línea a continuación.`,
 			share: {
-				button: 'TK'
+				button: 'Compartir'
 			}
 		},
 		tabs: {
-			serviceLineInformationTabTitle: 'TK',
-			serviceLineInventoryTabTitle: 'TK',
-			demographicContextTabTitle: 'TK'
+			serviceLineInformationTabTitle: 'Información de la\nlínea de servicio',
+			serviceLineInventoryTabTitle: 'Inventario de la\nlínea de servicio',
+			demographicContextTabTitle: 'Contexto\ndemográfico'
 		},
 		serviceLineInformation: {
-			loading: 'TK',
-			linesFound: 'TK',
+			loading: 'Cargando información de la línea de servicio...',
+			linesFound: 'líneas en esta dirección',
 			leadStatus: {
-				label: 'TK',
-				loading: 'TK',
-				C: 'TK',
-				CLS: 'TK',
-				G: 'TK',
-				GRR: 'TK',
-				L: 'TK',
-				NL: 'TK',
-				O: 'TK',
-				P: 'TK',
-				U: 'TK',
-				UNL: 'TK',
-				Unknown: 'TK'
+				label: 'Estado de plomo',
+				loading: 'Cargando...',
+				C: 'Cobre - Soldadura sin Plomo',
+				CLS: 'Cobre - Soldadura con Plomo',
+				G: 'Acero Galvanizado',
+				GRR: 'Acero Galvanizado que Requiere Reemplazo',
+				L: 'Plomo',
+				NL: 'Sin Plomo',
+				O: 'Hierro Fundido o Fibrocemento',
+				P: 'Plástico - PVC, HDPE, PEX',
+				U: 'Sospecha de Plomo',
+				UNL: 'Desconocido (Sin Plomo)',
+				Unknown: 'Desconocido'
 			},
 			components: {
-				publicSide: 'TK',
-				privateSide: 'TK',
-				waterMain: 'TK',
-				gooseneck: 'TK',
-				utilityPortion: 'TK',
-				customerPortion: 'TK',
-				ofServiceLine: 'TK',
-				utilitySide: 'TK',
-				customerSide: 'TK'
+				publicSide: 'Lado Público',
+				privateSide: 'Lado Privado',
+				waterMain: 'Tubería de agua',
+				gooseneck: 'Conector',
+				utilityPortion: 'Porción de servicio público',
+				customerPortion: 'Porción del cliente',
+				ofServiceLine: 'de la línea de servicio',
+				utilitySide: 'Lado de servicio público',
+				customerSide: 'Lado del cliente de la línea de servicio'
 			},
 			split: {
-				unknown: 'TK',
-				galvanizedRequiring: 'TK',
-				replacement: 'TK',
-				castDuctile: 'TK',
-				orTransite: 'TK',
-				copper: 'TK',
-				noLeadSolder: 'TK',
-				leadSolder: 'TK',
-				plastic: 'TK',
-				pvchdpepex: 'TK'
+				unknown: 'Desconocido',
+				notLead: '(Sin Plomo)',
+				galvanized: 'Acero Galvanizado',
+				requiring: 'que Requiere',
+				replacement: 'Reemplazo',
+				castDuctile: 'Hierro Fundido',
+				orTransite: 'o Fibrocemento',
+				copper: 'Cobre -',
+				noLeadSolder: 'Soldadura sin Plomo',
+				leadSolder: 'Soldadura con Plomo',
+				plastic: 'Plástico - ',
+				pvchdpepex: 'PVC, HDPE, PEX'
 			},
 			pagination: {
-				nextButton: 'TK',
-				previousButton: 'TK',
-				lineOf: ({ current, total }) => `TK ${current} TK ${total}`
+				nextButton: 'Próxima',
+				previousButton: 'Anterior',
+				lineOf: ({ current, total }) => `Línea ${current} de ${total}`
 			},
 			exceptions: {
-				highRisk: 'TK',
-				detailedInventoryUnavailable: 'TK',
-				leadStatusFromGeocoder: 'TK'
+				highRisk:
+					'⚠️ Esta dirección es considerada una propiedad de alto riesgo por la ciudad de Chicago.',
+				detailedInventoryUnavailable:
+					'Información detallada del inventario no está disponible para esta dirección.',
+				leadStatusFromGeocoder:
+					'La condición básica de plomo que se muestra arriba es según los datos disponibles en la base de datos de direcciones geocodificadas.'
 			}
 		},
 		areaContext: {
-			locatedIn: 'TK',
+			locatedIn: 'Esta dirección se encuentra en',
 			statisticsOn: {
-				communityArea: 'TK',
-				censusTract: 'TK'
+				communityArea: 'Las estadísticas de esta area comunitaria se encuentran abajo.',
+				censusTract: 'Las estadísticas sobre este tramo del Censo aparecen a continuación.'
 			},
 			interaction: {
-				tap: 'TK',
-				hoverOver: 'TK'
+				tap: 'Haz clic en',
+				hoverOver: 'Pasa el cursor sobre'
 			},
-			learnMore: 'TK'
+			learnMore: 'una condición de línea para obtener más información.'
 		},
 		serviceLineInventory: {
-			lead: 'TK',
-			suspectedLead: 'TK',
-			galvanizedReplace: 'TK',
-			nonLead: 'TK',
-			total: 'TK',
-			requiresReplacement: 'TK'
+			lead: 'Plomo',
+			suspectedLead: 'Sospecha de plomo',
+			galvanizedReplace: 'Acero galvanizado (Reemplazar)',
+			nonLead: 'Sin plomo',
+			total: 'Total',
+			requiresReplacement: 'Requiere reemplazar'
 		},
 		demographicContext: {
-			medianHouseholdIncome: 'TK',
-			povertyRate: 'TK',
-			blackPopulation: 'TK',
-			latinoPopulation: 'TK',
-			whitePopulation: 'TK',
-			asianPopulation: 'TK',
-			nonWhitePopulation: 'TK'
+			medianHouseholdIncome: 'Ingreso promedio',
+			povertyRate: 'Tasa de pobreza',
+			blackPopulation: 'Población afroamericana',
+			latinoPopulation: 'Población latina',
+			whitePopulation: 'Población blanca anglosajona',
+			asianPopulation: 'Población asiática',
+			nonWhitePopulation: 'Población no-blanca anglosajona'
 		},
 		tooltips: {
 			definitions: {
-				lead: 'TK',
-				suspectedLead: 'TK',
-				galvanized: 'TK',
-				nonLead: 'TK'
+				lead: 'Se sabe que al menos un componente de la línea de servicio está hecho de plomo.',
+				suspectedLead:
+					'La composición de la línea de servicio está marcada como desconocida en el inventario municipal, pero se sospecha que contiene componentes de plomo, generalmente debido a la antigüedad del edificio.',
+				galvanized:
+					'No se sabe de algún componente de la línea de servicio que esté hecho de plomo, pero al menos una parte es de acero galvanizado, que puede contaminarse con plomo de las tuberías de agua más elevadas.',
+				nonLead:
+					'Ninguno de los componentes de la línea de servicio está hecho ni puede estar contaminado con plomo.'
 			}
 		},
 		resources: {
-			button: 'TK',
+			button: 'Recursos para dirección seleccionada',
 			title: '¿Qué puedo hacer?',
-			resultDescription: ({ plural }) => `TK ${plural ? 'TK' : 'TK'}`,
+			resultDescription: ({ plural }) =>
+				`Según el resultado de su línea de servicio, ${plural ? 'los siguientes recursos están disponibles' : 'el siguiente recurso está disponible'}`,
 			freeWaterTestingKit: {
-				label: 'TK',
-				description: 'TK',
-				CTA: 'TK'
+				label: 'Kit de pruebas de agua gratuito',
+				description:
+					'Todos los residentes de Chicago pueden solicitar un kit de prueba de agua gratuito para verificar los niveles de plomo.',
+				CTA: 'Solicita un kit de pruebas de agua gratis'
 			},
 			freeWaterFilter: {
-				label: 'TK',
-				description: 'TK',
-				CTA: 'TK'
+				label: 'Filtro de agua gratuito',
+				description:
+					'Verifica si su dirección califica para un filtro de agua gratuito de la ciudad de Chicago.',
+				CTA: 'Inscríbete para un filtro de agua gratis'
 			},
 			leadPipeReplacementAssistance: {
-				label: 'TK',
-				description: 'TK',
-				CTA: 'TK'
+				label: 'Ayuda para reemplazar las pipas con plomo',
+				description:
+					'Dependiendo de tus ingresos, podrías calificar para el reemplazo gratuito de tuberías de plomo.',
+				CTA: 'Solicita ayuda para reemplazarlas'
 			}
 		},
 		share: {
-			title: 'TK',
-			downloadImage: 'TK',
-			saveToShare: 'TK',
+			title: 'Comparte tus resultados',
+			downloadImage: 'Descargar imagen',
+			saveToShare: 'Guardar esta imagen para compartir en redes sociales',
 			image: {
-				iLookedUp: 'TK',
-				in: 'TK',
-				and: 'TK',
-				foundOut: 'TK',
-				serviceLineMadeOf: 'TK',
+				iLookedUp: 'Busqué mi dirección',
+				in: 'en',
+				and: 'y',
+				foundOut: 'aprendí',
+				serviceLineMadeOf: 'de qué está hecha mi línea de servicio de agua',
 				leadStatus: {
-					L: 'TK',
-					GRR: 'TK',
-					NL: 'TK',
-					U: 'TK',
-					Unknown: 'TK'
+					L: 'Plomo',
+					GRR: 'Acero galvanizado que requiere reemplazo',
+					NL: 'Sin plomo',
+					U: 'Sospecha de plomo',
+					Unknown: 'Desconocido'
 				},
-				checkYourLeadStatus: 'TK'
+				checkYourLeadStatus: 'revisa la condición de plomo de tu hogar'
 			}
 		}
 	}

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -613,8 +613,8 @@ export const messages: Record<Language, Messages> = {
 				iLookedUp: 'Busqué mi dirección',
 				in: 'en',
 				and: 'y',
-				foundOut: 'aprendí',
-				serviceLineMadeOf: 'de qué está hecha mi línea de servicio de agua',
+				foundOut: 'aprendí de qué está hecha',
+				serviceLineMadeOf: 'mi línea de servicio de agua',
 				leadStatus: {
 					L: 'Plomo',
 					GRR: 'Acero galvanizado que requiere reemplazo',

--- a/src/lib/state/social.svelte.ts
+++ b/src/lib/state/social.svelte.ts
@@ -123,8 +123,23 @@ class SocialState {
 
 		ctx.fillStyle = 'white';
 		ctx.font = '48px "Basis Grotesque", -apple-system, sans-serif';
-		ctx.fillText(`Chicago, ${messages[lang].share.image.checkYourLeadStatus}:`, 80, 920);
-		ctx.fillText('grist.org/chicago-lead', 80, 980);
+
+		if (lang === 'en') {
+			ctx.fillText(`Chicago, ${messages[lang].share.image.checkYourLeadStatus}:`, 80, 920);
+			ctx.fillText('grist.org/chicago-lead', 80, 980);
+		} else {
+			ctx.fillText(
+				`Chicago, ${messages[lang].share.image.checkYourLeadStatus.split(' ').slice(0, 3).join(' ')}`,
+				80,
+				860
+			);
+			ctx.fillText(
+				`${messages[lang].share.image.checkYourLeadStatus.split(' ').slice(3).join(' ')}:`,
+				80,
+				920
+			);
+			ctx.fillText('grist.org/chicago-lead/?lang=es', 80, 980);
+		}
 
 		// Convert to blob and show preview
 		canvas.toBlob(

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -62,3 +62,40 @@ export function formatAreaIdentifier(
 
 	return '';
 }
+
+/**
+ * Format the display name of a service line material given its code.
+ *
+ * @param material – The material code to format.
+ * @param lang – The language to use.
+ * @returns The formatted display name of the service line material.
+ */
+export function formatServiceLineMaterial(
+	material: string,
+	{ lang = 'en' }: { lang?: Language }
+): string {
+	switch (material.toUpperCase()) {
+		case 'C':
+			return messages[lang].serviceLineInformation.leadStatus.C;
+		case 'CLS':
+			return messages[lang].serviceLineInformation.leadStatus.CLS;
+		case 'G':
+			return messages[lang].serviceLineInformation.leadStatus.G;
+		case 'GRR':
+			return messages[lang].serviceLineInformation.leadStatus.GRR;
+		case 'L':
+			return messages[lang].serviceLineInformation.leadStatus.L;
+		case 'O':
+			return messages[lang].serviceLineInformation.leadStatus.O;
+		case 'P':
+			return messages[lang].serviceLineInformation.leadStatus.P;
+		case 'U':
+			return messages[lang].serviceLineInformation.leadStatus.U;
+		case 'UNL':
+			return messages[lang].serviceLineInformation.leadStatus.UNL;
+		case 'NL':
+			return messages[lang].serviceLineInformation.leadStatus.NL;
+		default:
+			return material;
+	}
+}


### PR DESCRIPTION
A small posterity PR that includes Spanish translation copy. Some of the translations led to broken layout or overflowing text in the `ServiceLineDiagram` component due to the Spanish copy being significantly longer than the English equivalent. This PR tries to adjust for those as much as possible.